### PR TITLE
Убрать необходимость в правильном порядке инициализации FeatureToggleService и TracingFeatureFlagChecker

### DIFF
--- a/src/FeatureToggle/FeatureToggle/src/FeatureToggleService.cs
+++ b/src/FeatureToggle/FeatureToggle/src/FeatureToggleService.cs
@@ -78,6 +78,7 @@ public class FeatureToggleService : IFeatureToggleService
                 this.lazyFeatureToggleClient.Value
                     .GetAwaiter()
                     .GetResult();
+                this.ProcessTogglesUpdated();
             }
 
             var featureToggleClient = this.lazyFeatureToggleClient.IsValueCreated
@@ -114,9 +115,8 @@ public class FeatureToggleService : IFeatureToggleService
         if (!this.lazyFeatureToggleClient.IsValueCreated)
         {
             await this.lazyFeatureToggleClient.Value.ConfigureAwait(false);
+            this.ProcessTogglesUpdated();
         }
-
-        this.ProcessTogglesUpdated();
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
`TracingFeatureFlagChecker` зависит от `FeatureToggleService`.

```
services.AddDefaultTracing(this.Configuration);
services.ConfigureFeatureToggle<Startup>(this.Configuration);
```

Если сервисы были зарегистрированы в порядке, приведённом выше, `TracingFeatureFlagChecker` обращался к `FeatureToggleService`, что приводило к ошибке, так как инициализация `FeatureToggleService` происходит только при старте соответствующего ему `HostedService`.

Данный MR избавляет от этого неявного требования, обеспечивая корректную работу `TracingFeatureFlagChecker` независимо от порядка регистрации сервисов.

Альтернативно можно пробросить какое-нибудь `IFeatureToggleService.IsInitialized` свойство и корректно обрабатывать его в `TracingFeatureFlagChecker`, но протекание внутренних деталей реализации в публичный интерфейс мне нравится меньше, чем потенциальное и единственное на весь лайфтайм сервиса блокирование потока в синхронной среде.